### PR TITLE
Add role selection workflow

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,6 +12,7 @@ interface User {
   email: string
   name: string
   avatar?: string
+  role?: string
 }
 
 export default function ProfilePage() {
@@ -34,7 +35,13 @@ export default function ProfilePage() {
         if (!res.ok) throw new Error("Unauthorized")
         return res.json()
       })
-      .then((data: User) => setUser(data))
+      .then((data: User) => {
+        if (!data.role) {
+          router.push("/select-role")
+          return
+        }
+        setUser(data)
+      })
       .catch(() => router.push("/login"))
   }, [router])
 

--- a/src/app/select-role/page.tsx
+++ b/src/app/select-role/page.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+
+function getCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"))
+  return match ? decodeURIComponent(match[2]) : null
+}
+
+export default function SelectRolePage() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+
+  const handleSelect = async (role: string) => {
+    const token = getCookie("token")
+    if (!token) {
+      router.push("/login")
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch("https://api.aspirely.edu.vn/profile", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ role }),
+      })
+      if (!res.ok) throw new Error("Failed")
+      router.push("/profile")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    const token = getCookie("token")
+    if (!token) {
+      router.push("/login")
+    }
+  }, [router])
+
+  return (
+    <div className="w-full h-screen flex items-center justify-center">
+      <div className="space-x-4">
+        <button
+          onClick={() => handleSelect("student")}
+          disabled={loading}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Student
+        </button>
+        <button
+          onClick={() => handleSelect("teacher")}
+          disabled={loading}
+          className="px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Teacher
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add page for selecting user role
- redirect to `/select-role` if profile role is missing

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688351dc0060832cb1d48996a26c1662