### PR TITLE
Add API URL env variable

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://api.aspirely.edu.vn

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ pnpm dev
 bun dev
 ```
 
+Create a `.env.local` file in the project root and define the API base URL:
+
+```bash
+NEXT_PUBLIC_API_URL=https://api.aspirely.edu.vn
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/k8s/aspirely-app-frontend/deployment.yaml
+++ b/k8s/aspirely-app-frontend/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       containers:
         - name: aspirely-app-frontend
           image: ghcr.io/aspirelyvn/aspirely.app.frontend:latest
+          env:
+            - name: NEXT_PUBLIC_API_URL
+              value: "https://api.aspirely.edu.vn"
           ports:
             - containerPort: 3000
       imagePullSecrets:

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -25,11 +25,14 @@ function LoginContent() {
     }
     setError("")
     try {
-      const res = await fetch("https://api.aspirely.edu.vn/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(form),
-      })
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/login`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(form),
+        }
+      )
       if (!res.ok) throw new Error("Failed")
       const data = await res.json()
       Cookies.set("token", data.token, { expires: 7 })
@@ -98,7 +101,9 @@ function LoginContent() {
 
         <div className="grid grid-cols-3 gap-3">
           <button
-            onClick={() => (window.location.href = "https://api.aspirely.edu.vn/auth/google/login")}
+            onClick={() =>
+              (window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/auth/google/login`)
+            }
             className="flex items-center justify-center p-3 border rounded hover:bg-gray-50"
           >
             <FaGoogle className="text-red-500" />

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -32,11 +32,18 @@ export default function RegisterPage() {
 
     setError("")
     try {
-      const res = await fetch("https://api.aspirely.edu.vn/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: form.name, email: form.email, password: form.password }),
-      })
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/register`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: form.name,
+            email: form.email,
+            password: form.password,
+          }),
+        }
+      )
       if (!res.ok) throw new Error("Failed")
       const data = await res.json()
       Cookies.set("token", data.token, { expires: 7 })

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -26,7 +26,7 @@ export default function ProfileEditPage() {
       router.push("/login")
       return
     }
-    fetch("https://api.aspirely.edu.vn/profile", {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/profile`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -55,7 +55,7 @@ export default function ProfileEditPage() {
     }
     setLoading(true)
     try {
-      const res = await fetch("https://api.aspirely.edu.vn/profile", {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/profile`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -27,7 +27,7 @@ export default function ProfilePage() {
       return
     }
 
-    fetch("https://api.aspirely.edu.vn/profile", {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/profile`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/src/app/select-role/page.tsx
+++ b/src/app/select-role/page.tsx
@@ -20,7 +20,7 @@ export default function SelectRolePage() {
     }
     setLoading(true)
     try {
-      const res = await fetch("https://api.aspirely.edu.vn/profile", {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/profile`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- add `.env.local` with `NEXT_PUBLIC_API_URL`
- document variable in README
- reference `NEXT_PUBLIC_API_URL` in auth & profile pages
- pass variable via deployment manifest
- allow committing `.env.local`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688355612c3c832c8c55ef6ee59d8f25